### PR TITLE
Add facility for non-associated entities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,11 @@ enable_testing()
 
 list(APPEND test_exposition_only
     test/callable.cpp
-    test/nothrow_callable.cpp
     test/call_result_t.cpp
-    test/tag_invoke.cpp
     test/movable_value.cpp
+    test/non_associated.cpp
+    test/nothrow_callable.cpp
+    test/tag_invoke.cpp
     )
 
 list(APPEND test_components

--- a/include/functional.hpp
+++ b/include/functional.hpp
@@ -30,6 +30,7 @@
 
 #include <functional>
 #include <p2300/callable.hpp>
+#include <p2300/non_associated.hpp>
 #include <p2300/tag_invoke.hpp>
 
 // ----------------------------------------------------------------------------

--- a/include/p2300/non_associated.hpp
+++ b/include/p2300/non_associated.hpp
@@ -1,0 +1,56 @@
+// include/p2300/non_associated.hpp                                   -*-C++-*-
+// ----------------------------------------------------------------------------
+//  Copyright (C) 2021 Dietmar Kuehl http://www.dietmar-kuehl.de
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify,
+//  merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#ifndef INCLUDED_INCLUDE_P2300_NON_ASSOCIATED
+#define INCLUDED_INCLUDE_P2300_NON_ASSOCIATED
+
+// ----------------------------------------------------------------------------
+// [func.tag_invoke]
+#include <type_traits>
+
+namespace std
+{
+    template <class _Ty>
+    struct _Non_associated_entity
+    {
+        struct _Type
+        {
+            using type = _Ty;
+        };
+    };
+
+    template <class _Ty>
+    using __unassociate = typename _Non_associated_entity<_Ty>::_Type;
+
+    template <class _Ty>
+    using __reassociate = typename _Ty::type;
+
+    template <class _Ty>
+    concept __non_associated = same_as<_Ty, __unassociate<__reassociate<_Ty>>>;
+} // namespace std
+
+// ----------------------------------------------------------------------------
+
+#endif // INCLUDED_INCLUDE_P2300_NON_ASSOCIATED

--- a/test/non_associated.cpp
+++ b/test/non_associated.cpp
@@ -42,3 +42,19 @@ TEST(non_associated, smoke_test)
     static_assert(is_invocable_v<meow, __unassociate<int>>);
     static_assert(same_as<int, __reassociate<__unassociate<int>>>);
 }
+
+namespace non_associated {
+    struct woof {};
+    constexpr void test_associated(auto);
+}
+
+template <typename, class = void>
+constexpr bool is_associated = false;
+template <typename T>
+constexpr bool is_associated<T, void_t<decltype(test_associated(declval<T>()))>> = true;
+
+TEST(non_associated, test_adl)
+{
+    static_assert(is_associated<non_associated::woof>);
+    static_assert(!is_associated<__unassociate<non_associated::woof>>);
+}

--- a/test/non_associated.cpp
+++ b/test/non_associated.cpp
@@ -1,0 +1,44 @@
+// test/non_associated.cpp                                         -*-C++-*-
+// ----------------------------------------------------------------------------
+//  Copyright (C) 2021 Dietmar Kuehl http://www.dietmar-kuehl.de
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify,
+//  merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "test-config.hpp"
+#include P2300_execution
+#include P2300_type_traits
+#include <gtest/gtest.h>
+
+using namespace std;
+// ----------------------------------------------------------------------------
+
+struct meow
+{
+    template <__non_associated T>
+    void operator()(T) {}
+};
+TEST(non_associated, smoke_test)
+{
+    static_assert(!is_invocable_v<meow, int>);
+    static_assert(is_invocable_v<meow, __unassociate<int>>);
+    static_assert(same_as<int, __reassociate<__unassociate<int>>>);
+}


### PR DESCRIPTION
There might be a bit more discussion here.

In a nutshell this adds facilities to enforce that template arguments are indeed not associated entities as described in P2300.

I am quite unhappy that we need to instantiate two types for it to work but I think this might later get some compiler support.

Thoughts? @ericniebler